### PR TITLE
Add framework adapters and Eikon connector to Finax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Diffrax-for-Information-Asymmetries
+# Finax
+
+Finax is a Python library built on top of JAX and Diffrax for financial data
+processing and modeling with neural ordinary and stochastic differential
+equations. This repository currently contains the initial skeleton of the
+package.
+
+## Package Structure
+
+- `finax/data` – loading, cleaning, feature engineering, and API connectors
+  such as Refinitiv Eikon.
+- `finax/modeling` – neural ODE/SDE abstractions, training helpers, and
+  adapters for TensorFlow and PyTorch models.
+- `finax/evaluation` – performance metrics.
+- `finax/infrastructure` – configuration helpers.
+- `finax/utils` – shared utilities such as logging.
+
+The project will expand with additional connectors, models, and training
+routines as development progresses.

--- a/finax/__init__.py
+++ b/finax/__init__.py
@@ -1,0 +1,14 @@
+"""Finax: Financial modeling tools built on JAX and Diffrax.
+
+This package provides utilities for loading and cleaning financial data,
+with modeling capabilities powered by neural ordinary and stochastic
+differential equations.
+"""
+
+__all__ = [
+    "data",
+    "modeling",
+    "evaluation",
+    "infrastructure",
+    "utils",
+]

--- a/finax/data/__init__.py
+++ b/finax/data/__init__.py
@@ -1,0 +1,18 @@
+"""Data utilities for Finax."""
+
+from .ingestion import load_csv, load_parquet, load_json, fetch_yahoo
+from .cleaning import fill_missing, detect_outliers
+from .features import rolling_mean, technical_indicator
+from .eikon import fetch_eikon
+
+__all__ = [
+    "load_csv",
+    "load_parquet",
+    "load_json",
+    "fetch_yahoo",
+    "fetch_eikon",
+    "fill_missing",
+    "detect_outliers",
+    "rolling_mean",
+    "technical_indicator",
+]

--- a/finax/data/cleaning.py
+++ b/finax/data/cleaning.py
@@ -1,0 +1,17 @@
+"""Data cleaning utilities for Finax."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def fill_missing(df: pd.DataFrame) -> pd.DataFrame:
+    """Fill missing values with forward fill."""
+    return df.ffill()
+
+
+def detect_outliers(df: pd.DataFrame, threshold: float = 3.0) -> pd.DataFrame:
+    """Replace values with NaN when their z-score exceeds ``threshold``."""
+    numeric = df.select_dtypes("number")
+    z = (numeric - numeric.mean()) / numeric.std(ddof=0)
+    return df.mask(abs(z) > threshold)

--- a/finax/data/eikon.py
+++ b/finax/data/eikon.py
@@ -1,0 +1,50 @@
+"""Refinitiv Eikon data connector."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    import eikon  # type: ignore
+except Exception:  # pragma: no cover
+    eikon = None  # type: ignore
+
+
+def fetch_eikon(
+    symbol: str,
+    *,
+    fields: Optional[list[str]] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> pd.DataFrame:
+    """Fetch time series data from Refinitiv Eikon.
+
+    Parameters
+    ----------
+    symbol:
+        Instrument identifier (RIC).
+    fields:
+        Optional list of fields to request.
+    start_date, end_date:
+        Date range for the request.
+    api_key:
+        Application key for authenticating with the Eikon API. If omitted, the
+        function relies on previously configured environment variables.
+    """
+
+    if eikon is None:  # pragma: no cover - runtime check
+        raise ImportError("The 'eikon' package is required for Refinitiv access.")
+
+    if api_key is not None:
+        eikon.set_app_key(api_key)
+
+    data = eikon.get_timeseries(
+        symbols=symbol,
+        fields=fields,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return data

--- a/finax/data/features.py
+++ b/finax/data/features.py
@@ -1,0 +1,15 @@
+"""Feature engineering utilities for Finax."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def rolling_mean(series: pd.Series, window: int) -> pd.Series:
+    """Compute a rolling mean over ``window`` observations."""
+    return series.rolling(window).mean()
+
+
+def technical_indicator(series: pd.Series) -> pd.Series:
+    """Placeholder for a technical indicator such as RSI."""
+    raise NotImplementedError("Indicator not implemented.")

--- a/finax/data/ingestion.py
+++ b/finax/data/ingestion.py
@@ -1,0 +1,27 @@
+"""Data ingestion utilities for Finax."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+
+def load_csv(path: str, *, parse_dates: Optional[list[str]] = None) -> pd.DataFrame:
+    """Load CSV financial data into a DataFrame."""
+    return pd.read_csv(path, parse_dates=parse_dates)
+
+
+def load_parquet(path: str) -> pd.DataFrame:
+    """Load Parquet financial data into a DataFrame."""
+    return pd.read_parquet(path)
+
+
+def load_json(path: str) -> pd.DataFrame:
+    """Load JSON financial data into a DataFrame."""
+    return pd.read_json(path)
+
+
+def fetch_yahoo(symbol: str) -> pd.DataFrame:
+    """Placeholder for Yahoo Finance API connector."""
+    raise NotImplementedError("API connector not implemented.")

--- a/finax/evaluation/__init__.py
+++ b/finax/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Evaluation helpers for Finax."""
+
+from .metrics import rmse, sharpe_ratio
+
+__all__ = ["rmse", "sharpe_ratio"]

--- a/finax/evaluation/metrics.py
+++ b/finax/evaluation/metrics.py
@@ -1,0 +1,17 @@
+"""Evaluation metrics for Finax."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def rmse(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Root mean squared error."""
+    diff = np.asarray(y_true) - np.asarray(y_pred)
+    return float(np.sqrt(np.mean(diff**2)))
+
+
+def sharpe_ratio(returns: np.ndarray, risk_free: float = 0.0) -> float:
+    """Compute the Sharpe ratio of a return series."""
+    excess = np.asarray(returns) - risk_free
+    return float(np.mean(excess) / np.std(excess, ddof=1))

--- a/finax/infrastructure/__init__.py
+++ b/finax/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure utilities for Finax."""
+
+from .config import load_config
+
+__all__ = ["load_config"]

--- a/finax/infrastructure/config.py
+++ b/finax/infrastructure/config.py
@@ -1,0 +1,13 @@
+"""Configuration utilities for Finax."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_config(path: str | Path) -> Dict[str, Any]:
+    """Load configuration from a JSON file."""
+    with open(path, "r", encoding="utf-8") as file:
+        return json.load(file)

--- a/finax/modeling/__init__.py
+++ b/finax/modeling/__init__.py
@@ -1,0 +1,17 @@
+"""Modeling utilities for Finax."""
+
+from .neural_ode import NeuralODE
+from .neural_sde import NeuralSDE
+from .training import train
+from .simulation import simulate_paths
+from .tf_integration import keras_to_jax
+from .torch_integration import torch_module_to_jax
+
+__all__ = [
+    "NeuralODE",
+    "NeuralSDE",
+    "train",
+    "simulate_paths",
+    "keras_to_jax",
+    "torch_module_to_jax",
+]

--- a/finax/modeling/neural_ode.py
+++ b/finax/modeling/neural_ode.py
@@ -1,0 +1,35 @@
+"""Neural ordinary differential equation models."""
+
+from __future__ import annotations
+
+from typing import Callable, Any
+
+try:  # pragma: no cover - handled at runtime
+    import jax.numpy as jnp  # noqa: F401
+    import diffrax  # noqa: F401
+except Exception:  # pragma: no cover - the dependencies are optional at import time
+    jnp = None  # type: ignore
+    diffrax = None  # type: ignore
+
+
+class NeuralODE:
+    """Basic neural ODE wrapper.
+
+    Parameters
+    ----------
+    vector_field:
+        Callable representing the derivative ``dy/dt = f(t, y, params)``.
+    """
+
+    def __init__(self, vector_field: Callable[[Any, Any, Any], Any]):
+        self.vector_field = vector_field
+
+    def solve(self, y0: Any, t0: float, t1: float, **kwargs: Any) -> Any:
+        """Solve the ODE from ``t0`` to ``t1`` starting at ``y0``.
+
+        This method requires JAX and Diffrax to be installed. It is a
+        lightweight placeholder for future solver configuration.
+        """
+        if diffrax is None:
+            raise ImportError("JAX and Diffrax are required for solving ODEs.")
+        return diffrax.diffeqsolve(self.vector_field, t0=t0, t1=t1, y0=y0, **kwargs)

--- a/finax/modeling/neural_sde.py
+++ b/finax/modeling/neural_sde.py
@@ -1,0 +1,41 @@
+"""Neural stochastic differential equation models."""
+
+from __future__ import annotations
+
+from typing import Callable, Any
+
+try:  # pragma: no cover - handled at runtime
+    import jax.numpy as jnp  # noqa: F401
+    import diffrax  # noqa: F401
+except Exception:  # pragma: no cover - the dependencies are optional at import time
+    jnp = None  # type: ignore
+    diffrax = None  # type: ignore
+
+
+class NeuralSDE:
+    """Basic neural SDE wrapper with drift and diffusion terms."""
+
+    def __init__(self, drift: Callable[[Any, Any, Any], Any], diffusion: Callable[[Any, Any, Any], Any]):
+        self.drift = drift
+        self.diffusion = diffusion
+
+    def simulate(self, y0: Any, t0: float, t1: float, *, key: Any, **kwargs: Any) -> Any:
+        """Simulate the SDE path.
+
+        Parameters
+        ----------
+        y0: initial state
+        t0, t1: time interval
+        key: random key for stochastic integration
+        """
+        if diffrax is None:
+            raise ImportError("JAX and Diffrax are required for simulation.")
+        return diffrax.diffeqsolve(
+            self.drift,
+            t0=t0,
+            t1=t1,
+            y0=y0,
+            args=(self.diffusion,),
+            key=key,
+            **kwargs,
+        )

--- a/finax/modeling/simulation.py
+++ b/finax/modeling/simulation.py
@@ -1,0 +1,10 @@
+"""Simulation utilities for Finax."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def simulate_paths(model: Any, *, n_paths: int, **kwargs: Any) -> Any:
+    """Placeholder for Monte Carlo path simulation."""
+    raise NotImplementedError("Simulation routine not implemented.")

--- a/finax/modeling/tf_integration.py
+++ b/finax/modeling/tf_integration.py
@@ -1,0 +1,38 @@
+"""TensorFlow integration utilities for Finax."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+try:  # pragma: no cover - optional dependency
+    import tensorflow as tf  # type: ignore
+except Exception:  # pragma: no cover - handled at runtime
+    tf = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import jax.numpy as jnp  # type: ignore
+    import numpy as np
+except Exception:  # pragma: no cover - handled at runtime
+    jnp = None  # type: ignore
+    np = None  # type: ignore
+
+
+def keras_to_jax(model: "tf.keras.Model") -> Callable[[Any], Any]:
+    """Wrap a Keras model as a JAX-callable function.
+
+    This helper runs the underlying TensorFlow model in inference mode and
+    converts the output to ``jax.numpy`` arrays so it can be used inside JAX
+    and Diffrax pipelines.
+    """
+
+    if tf is None or jnp is None or np is None:  # pragma: no cover - runtime check
+        raise ImportError("TensorFlow, NumPy, and JAX are required for this utility.")
+
+    model.trainable = False
+
+    def wrapped(x: Any) -> Any:
+        tensor = tf.convert_to_tensor(np.asarray(x))
+        result = model(tensor)
+        return jnp.asarray(result.numpy())
+
+    return wrapped

--- a/finax/modeling/torch_integration.py
+++ b/finax/modeling/torch_integration.py
@@ -1,0 +1,41 @@
+"""PyTorch integration utilities for Finax."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+try:  # pragma: no cover - optional dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover
+    torch = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import jax.numpy as jnp  # type: ignore
+    import numpy as np
+except Exception:  # pragma: no cover
+    jnp = None  # type: ignore
+    np = None  # type: ignore
+
+
+def torch_module_to_jax(module: "torch.nn.Module") -> Callable[[Any], Any]:
+    """Wrap a PyTorch module as a JAX-callable function.
+
+    Parameters
+    ----------
+    module:
+        A ``torch.nn.Module`` set to evaluation mode. The wrapper converts input
+        arrays to torch tensors and returns the output as ``jax.numpy`` arrays.
+    """
+
+    if torch is None or jnp is None or np is None:  # pragma: no cover - runtime check
+        raise ImportError("PyTorch, NumPy, and JAX are required for this utility.")
+
+    module.eval()
+
+    def wrapped(x: Any) -> Any:
+        with torch.no_grad():
+            tensor = torch.as_tensor(np.asarray(x))
+            result = module(tensor)
+        return jnp.asarray(result.numpy())
+
+    return wrapped

--- a/finax/modeling/training.py
+++ b/finax/modeling/training.py
@@ -1,0 +1,20 @@
+"""Training utilities for Finax models."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def train(model: Callable[..., Any], data: Any, *, steps: int = 100) -> None:
+    """Placeholder training loop for models.
+
+    Parameters
+    ----------
+    model:
+        Callable with ``params`` and ``batch`` arguments.
+    data:
+        Training data or iterator.
+    steps:
+        Number of optimization steps.
+    """
+    raise NotImplementedError("Training routine not implemented.")

--- a/finax/utils/__init__.py
+++ b/finax/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for Finax."""
+
+from .logging import get_logger
+
+__all__ = ["get_logger"]

--- a/finax/utils/logging.py
+++ b/finax/utils/logging.py
@@ -1,0 +1,19 @@
+"""Logging helpers for Finax."""
+
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Create and configure a package logger."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "finax"
+version = "0.1.0"
+description = "Financial modeling on JAX and Diffrax"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "jax",
+    "diffrax",
+    "pandas",
+    "numpy",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+tensorflow = ["tensorflow"]
+torch = ["torch"]
+eikon = ["eikon"]


### PR DESCRIPTION
## Summary
- document Eikon API connector and TensorFlow/PyTorch adapters in README
- add Refinitiv Eikon data fetcher and export from data package
- introduce adapters wrapping Keras and PyTorch models for JAX/Diffrax
- declare optional dependencies for TensorFlow, PyTorch, and Eikon

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e08acaee48325b55e0f122ef0cb0e