### PR TITLE
Add technical indicators and event annotation utilities

### DIFF
--- a/finax/data/__init__.py
+++ b/finax/data/__init__.py
@@ -1,8 +1,30 @@
-"""Data utilities for Finax."""
+"""Data utilities for Finax.
+
+This submodule collects helpers for loading, cleaning and engineering
+financial time series.
+
+Examples
+--------
+>>> import pandas as pd
+>>> from finax.data import rsi, event_flags
+>>> prices = pd.Series([1, 2, 3], index=pd.date_range("2024-01-01", periods=3))
+>>> rsi(prices, window=2).round(0).tolist()
+[nan, 100.0, 100.0]
+>>> events = pd.DataFrame({"date": [pd.Timestamp("2024-01-02")], "event": ["earnings"]})
+>>> event_flags(prices.to_frame("price"), events).loc["2024-01-02", "earnings"]
+1
+"""
 
 from .ingestion import load_csv, load_parquet, load_json, fetch_yahoo
 from .cleaning import fill_missing, detect_outliers
-from .features import rolling_mean, technical_indicator
+from .features import (
+    rolling_mean,
+    rsi,
+    macd,
+    bollinger_bands,
+    rolling_volatility,
+    event_flags,
+)
 from .eikon import fetch_eikon
 
 __all__ = [
@@ -14,5 +36,9 @@ __all__ = [
     "fill_missing",
     "detect_outliers",
     "rolling_mean",
-    "technical_indicator",
+    "rsi",
+    "macd",
+    "bollinger_bands",
+    "rolling_volatility",
+    "event_flags",
 ]

--- a/finax/data/features.py
+++ b/finax/data/features.py
@@ -10,6 +10,84 @@ def rolling_mean(series: pd.Series, window: int) -> pd.Series:
     return series.rolling(window).mean()
 
 
-def technical_indicator(series: pd.Series) -> pd.Series:
-    """Placeholder for a technical indicator such as RSI."""
-    raise NotImplementedError("Indicator not implemented.")
+def rsi(series: pd.Series, window: int = 14) -> pd.Series:
+    """Compute the Relative Strength Index (RSI).
+
+    Parameters
+    ----------
+    series:
+        Price series.
+    window:
+        Number of periods to use for averaging gains and losses.
+    """
+    diff = series.diff()
+    gain = diff.clip(lower=0)
+    loss = -diff.clip(upper=0)
+    avg_gain = gain.rolling(window).mean()
+    avg_loss = loss.rolling(window).mean()
+    rs = avg_gain / avg_loss
+    rsi_val = 100 - 100 / (1 + rs)
+    rsi_val = rsi_val.where(avg_loss != 0, 100)
+    rsi_val = rsi_val.where(avg_gain != 0, 0)
+    return rsi_val
+
+
+def macd(
+    series: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9
+) -> pd.DataFrame:
+    """Compute the Moving Average Convergence Divergence (MACD).
+
+    Returns a ``DataFrame`` with ``macd``, ``signal`` and ``hist`` columns.
+    """
+    fast_ema = series.ewm(span=fast, adjust=False).mean()
+    slow_ema = series.ewm(span=slow, adjust=False).mean()
+    macd_line = fast_ema - slow_ema
+    signal_line = macd_line.ewm(span=signal, adjust=False).mean()
+    hist = macd_line - signal_line
+    return pd.DataFrame({"macd": macd_line, "signal": signal_line, "hist": hist})
+
+
+def bollinger_bands(
+    series: pd.Series, window: int = 20, num_std: float = 2.0
+) -> pd.DataFrame:
+    """Compute Bollinger Bands.
+
+    Returns a ``DataFrame`` with ``middle``, ``upper`` and ``lower`` bands.
+    """
+    middle = series.rolling(window).mean()
+    std = series.rolling(window).std()
+    upper = middle + num_std * std
+    lower = middle - num_std * std
+    return pd.DataFrame({"middle": middle, "upper": upper, "lower": lower})
+
+
+def rolling_volatility(series: pd.Series, window: int) -> pd.Series:
+    """Compute the rolling volatility from percentage returns."""
+    returns = series.pct_change()
+    return returns.rolling(window).std()
+
+
+def event_flags(df: pd.DataFrame, events: pd.DataFrame) -> pd.DataFrame:
+    """Annotate price ``df`` with binary flags for specified ``events``.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with a ``DatetimeIndex``.
+    events:
+        DataFrame with ``date`` and ``event`` columns. ``date`` should be
+        convertible to ``datetime``.
+    """
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise ValueError("df must have a DatetimeIndex")
+
+    flagged = df.copy()
+    events = events.copy()
+    events["date"] = pd.to_datetime(events["date"])
+
+    for name, group in events.groupby("event"):
+        flagged[name] = (
+            flagged.index.normalize().isin(group["date"].dt.normalize()).astype(int)
+        )
+
+    return flagged

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pandas.testing as tm
+
+# Ensure package root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from finax.data import (
+    rsi,
+    macd,
+    bollinger_bands,
+    rolling_volatility,
+    event_flags,
+)
+
+
+def test_rsi_basic():
+    s = pd.Series(range(1, 11), dtype=float)
+    result = rsi(s, window=2)
+    assert pd.isna(result.iloc[0])
+    assert result.iloc[-1] == 100
+
+
+def test_macd_matches_manual():
+    s = pd.Series(range(1, 11), dtype=float)
+    out = macd(s)
+    fast_ema = s.ewm(span=12, adjust=False).mean()
+    slow_ema = s.ewm(span=26, adjust=False).mean()
+    macd_line = fast_ema - slow_ema
+    signal_line = macd_line.ewm(span=9, adjust=False).mean()
+    hist = macd_line - signal_line
+    tm.assert_series_equal(out["macd"], macd_line, check_names=False)
+    tm.assert_series_equal(out["signal"], signal_line, check_names=False)
+    tm.assert_series_equal(out["hist"], hist, check_names=False)
+
+
+def test_bollinger_bands():
+    s = pd.Series(range(1, 21), dtype=float)
+    bands = bollinger_bands(s, window=5, num_std=2)
+    middle = s.rolling(5).mean()
+    std = s.rolling(5).std()
+    upper = middle + 2 * std
+    lower = middle - 2 * std
+    tm.assert_series_equal(bands["middle"], middle, check_names=False)
+    tm.assert_series_equal(bands["upper"], upper, check_names=False)
+    tm.assert_series_equal(bands["lower"], lower, check_names=False)
+
+
+def test_rolling_volatility():
+    s = pd.Series([1, 2, 4, 8, 16], dtype=float)
+    vol = rolling_volatility(s, window=2)
+    expected = s.pct_change().rolling(2).std()
+    tm.assert_series_equal(vol, expected)
+
+
+def test_event_flags():
+    idx = pd.date_range("2024-01-01", periods=3)
+    df = pd.DataFrame({"price": [1, 2, 3]}, index=idx)
+    events = pd.DataFrame({"date": [pd.Timestamp("2024-01-02")], "event": ["earnings"]})
+    flagged = event_flags(df, events)
+    assert "earnings" in flagged.columns
+    assert flagged.loc[pd.Timestamp("2024-01-02"), "earnings"] == 1
+    assert flagged["earnings"].sum() == 1


### PR DESCRIPTION
## Summary
- Implement RSI, MACD, Bollinger Bands, rolling volatility, and event flag utilities
- Expand data subpackage documentation and re-export new helpers
- Add tests covering indicator calculations and event annotation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e134c5d088325be9c3f5655bcdf38