### PR TITLE
Add rolling CV and training hooks

### DIFF
--- a/finax/modeling/__init__.py
+++ b/finax/modeling/__init__.py
@@ -2,7 +2,7 @@
 
 from .neural_ode import NeuralODE
 from .neural_sde import NeuralSDE
-from .training import train
+from .training import train, rolling_cv
 from .simulation import simulate_paths
 from .tf_integration import keras_to_jax
 from .torch_integration import torch_module_to_jax
@@ -14,6 +14,7 @@ __all__ = [
     "NeuralODE",
     "NeuralSDE",
     "train",
+    "rolling_cv",
     "simulate_paths",
     "keras_to_jax",
     "torch_module_to_jax",

--- a/finax/modeling/training.py
+++ b/finax/modeling/training.py
@@ -1,20 +1,114 @@
-"""Training utilities for Finax models."""
+"""Training utilities for Finax models.
+
+This module exposes two utilities:
+
+``train``
+    A minimal training loop with optional early-stopping and learning rate
+    scheduling hooks. Users provide a ``step_fn`` which performs one update and
+    returns a metric (typically the loss) for the current iteration::
+
+        >>> data = [1, 2, 3]
+        >>> def step_fn(batch, lr, step):
+        ...     return batch * lr
+        >>> train(step_fn, data, steps=3, lr_schedule=lambda s: 0.1)
+
+``rolling_cv``
+    A generator yielding rolling-window train/test splits, useful for
+    time-series cross validation::
+
+        >>> data = list(range(10))
+        >>> for train_split, test_split in rolling_cv(lambda x: x, data, 4, 2):
+        ...     pass
+
+Both utilities are intentionally lightweight to accommodate a variety of model
+types and optimisation strategies.
+"""
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Iterable
+from typing import Any, Callable, Generator, Tuple
 
 
-def train(model: Callable[..., Any], data: Any, *, steps: int = 100) -> None:
-    """Placeholder training loop for models.
+def train(
+    step_fn: Callable[[Any, float, int], float],
+    data: Iterable[Any],
+    *,
+    steps: int = 100,
+    early_stopping: Callable[[int, float], bool] | None = None,
+    lr_schedule: Callable[[int], float] | None = None,
+) -> Tuple[int, float]:
+    """Run a simple training loop.
 
     Parameters
     ----------
-    model:
-        Callable with ``params`` and ``batch`` arguments.
+    step_fn:
+        Callable taking ``(batch, learning_rate, step)`` and returning a metric
+        (e.g. loss) for the step.
     data:
-        Training data or iterator.
+        Iterable of batches supplied to ``step_fn``.
     steps:
-        Number of optimization steps.
+        Maximum number of optimisation steps.
+    early_stopping:
+        Optional callable ``(step, metric) -> bool``. If it returns ``True`` the
+        loop terminates early.
+    lr_schedule:
+        Optional callable ``step -> learning_rate`` used to adjust the learning
+        rate per iteration.
+
+    Returns
+    -------
+    Tuple[int, float]
+        The last completed step index and its associated metric.
     """
-    raise NotImplementedError("Training routine not implemented.")
+
+    iterator = iter(data)
+    metric = float("nan")
+    for step in range(steps):
+        try:
+            batch = next(iterator)
+        except StopIteration:  # pragma: no cover - defensive
+            iterator = iter(data)
+            batch = next(iterator)
+
+        lr = lr_schedule(step) if lr_schedule is not None else 1.0
+        metric = step_fn(batch, lr, step)
+
+        if early_stopping is not None and early_stopping(step, metric):
+            break
+
+    return step, metric
+
+
+def rolling_cv(
+    train_fn: Callable[[Iterable[Any]], Any],
+    data: Iterable[Any],
+    window: int,
+    step: int,
+) -> Generator[Tuple[Any, Iterable[Any]], None, None]:
+    """Generate rolling-window train/test splits.
+
+    Parameters
+    ----------
+    train_fn:
+        Callable applied to each training split.
+    data:
+        Sequence of observations.
+    window:
+        Size of the training window.
+    step:
+        Step size between windows and the size of the test split.
+
+    Yields
+    ------
+    Tuple[Any, Iterable[Any]]
+        The result of ``train_fn`` on the current training split and the
+        corresponding test split.
+    """
+
+    data = list(data)
+    n = len(data)
+    for start in range(0, n - window, step):
+        train_split = data[start : start + window]
+        test_split = data[start + window : start + window + step]
+        yield train_fn(train_split), test_split

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,46 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from finax.modeling.training import rolling_cv, train
+
+
+def test_rolling_cv_boundaries():
+    data = list(range(10))
+    window = 4
+    step = 2
+    splits = list(rolling_cv(lambda x: x, data, window, step))
+    assert splits == [
+        (list(range(0, 4)), list(range(4, 6))),
+        (list(range(2, 6)), list(range(6, 8))),
+        (list(range(4, 8)), list(range(8, 10))),
+    ]
+
+
+def test_early_stopping():
+    data = [None] * 10
+
+    metrics = []
+
+    def step_fn(batch, lr, step):
+        metric = 1.0 / (step + 1)
+        metrics.append(metric)
+        return metric
+
+    def early_stop(step, metric):
+        return metric < 0.3
+
+    last_step, last_metric = train(
+        step_fn,
+        data,
+        steps=10,
+        early_stopping=early_stop,
+        lr_schedule=lambda s: 1.0,
+    )
+
+    assert last_step == 3
+    assert pytest.approx(last_metric) == 0.25
+    assert len(metrics) == 4


### PR DESCRIPTION
## Summary
- implement minimal `train` loop supporting early stopping and learning-rate schedules
- add `rolling_cv` generator for rolling-window cross validation
- document and export new utilities
- test split boundaries and early-stopping behaviour on toy data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e136db78483258c020fadac66f6de